### PR TITLE
OCPBUGS-11137: Add configmap to store subscriber info as a storage type - To prevent loss of subscribers

### DIFF
--- a/routes.go
+++ b/routes.go
@@ -157,10 +157,22 @@ func (s *Server) createPublisher(w http.ResponseWriter, r *http.Request) {
 func (s *Server) sendOut(eType channel.Type, sub *pubsub.PubSub) {
 	// go ahead and create QDR to this address
 	s.dataOut <- &channel.DataChan{
+		ID:      sub.GetID(),
 		Address: sub.GetResource(),
 		Data:    &ce.Event{},
 		Type:    eType,
 		Status:  channel.NEW,
+	}
+}
+
+func (s *Server) sendOutToDelete(eType channel.Type, sub *pubsub.PubSub) {
+	// go ahead and create QDR to this address
+	s.dataOut <- &channel.DataChan{
+		ID:      sub.GetID(),
+		Address: sub.GetResource(),
+		Data:    &ce.Event{},
+		Type:    eType,
+		Status:  channel.DELETE,
 	}
 }
 
@@ -257,6 +269,8 @@ func (s *Server) deleteAllSubscriptions(w http.ResponseWriter, r *http.Request) 
 	if size > 0 {
 		localmetrics.UpdateSubscriptionCount(localmetrics.ACTIVE, -(size))
 	}
+	// go ahead and create QDR to this address
+	s.sendOutToDelete(channel.SUBSCRIBER, &pubsub.PubSub{ID: "", Resource: "delete-all-subscriptions"})
 	respondWithMessage(w, http.StatusOK, "deleted all subscriptions")
 }
 


### PR DESCRIPTION
Update rest API to support config map  and delete all  subscriber