### PR TITLE
fix subscription for multiple clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ pub.json
 sub.json
 
 .idea
+.cache
+.dccache
+

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.0
 	github.com/prometheus/client_golang v1.14.0
-	github.com/redhat-cne/sdk-go v1.22.0
+	github.com/redhat-cne/sdk-go v1.22.2
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/net v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ github.com/prometheus/common v0.42.0 h1:EKsfXEYo4JpWMHH5cg+KOUWeuJSov1Id8zGR8eeI
 github.com/prometheus/common v0.42.0/go.mod h1:xBwqVerjNdUDjgODMpudtOMwlOwf2SaTr1yjz4b7Zbc=
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
-github.com/redhat-cne/sdk-go v1.22.0 h1:oAfCu9jjXLn3/aXASuccZCX1Vlz9iIV9pmuO4vy4dSk=
-github.com/redhat-cne/sdk-go v1.22.0/go.mod h1:qeir05dwTscLvqGCIoQPCUM6HUoVmhR7521nXn28utA=
+github.com/redhat-cne/sdk-go v1.22.2 h1:4pyXsvnNGY+n7LITmppoEUgYM+4uDRV/jpdHtjgFn9c=
+github.com/redhat-cne/sdk-go v1.22.2/go.mod h1:qeir05dwTscLvqGCIoQPCUM6HUoVmhR7521nXn28utA=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=

--- a/v2/routes.go
+++ b/v2/routes.go
@@ -68,12 +68,13 @@ func (s *Server) createSubscription(w http.ResponseWriter, r *http.Request) {
 		localmetrics.UpdateSubscriptionCount(localmetrics.FAILCREATE, 1)
 		return
 	}
-	clientIDs := s.subscriberAPI.GetClientIDByResource(sub.GetResource())
-	if len(clientIDs) != 0 {
-		respondWithStatusCode(w, http.StatusConflict,
-			fmt.Sprintf("subscription (clientID: %s) with same resource already exists, skipping creation",
-				clientIDs[0]))
-		return
+	for id, address := range s.subscriberAPI.GetClientIDAddressByResource(sub.GetResource()) {
+		if address.String() == endPointURI {
+			respondWithStatusCode(w, http.StatusConflict,
+				fmt.Sprintf("subscription (clientID: %s) with same resource already exists, skipping creation",
+					id))
+			return
+		}
 	}
 
 	id := uuid.New().String()

--- a/v2/server.go
+++ b/v2/server.go
@@ -309,7 +309,10 @@ func (s *Server) Start() {
 		io.WriteString(w, "OK") //nolint:errcheck
 	}).Methods(http.MethodGet)
 
+	// for internal test
 	api.HandleFunc("/dummy", dummy).Methods(http.MethodPost)
+	// for internal test: test multiple clients
+	api.HandleFunc("/dummy2", dummy).Methods(http.MethodPost)
 	api.HandleFunc("/log", s.logEvent).Methods(http.MethodPost)
 
 	//publishEvent create event and send it to a channel that is shared by middleware to process

--- a/vendor/github.com/redhat-cne/sdk-go/pkg/event/ptp/resource.go
+++ b/vendor/github.com/redhat-cne/sdk-go/pkg/event/ptp/resource.go
@@ -30,6 +30,10 @@ const (
 	// PtpClockClass notification is generated when the clock-class changes.
 	PtpClockClass EventResource = "/sync/ptp-status/clock-class"
 
+	// Support V1
+	// PtpClockClassV1 notification is generated when the clock-class changes for v1.
+	PtpClockClassV1 EventResource = "/sync/ptp-status/ptp-clock-class-change"
+
 	// O-RAN 7.2.3.3
 	// PtpLockState notification is signalled from equipment at state change
 	PtpLockState EventResource = "/sync/ptp-status/lock-state"

--- a/vendor/github.com/redhat-cne/sdk-go/v1/subscriber/subscriber.go
+++ b/vendor/github.com/redhat-cne/sdk-go/v1/subscriber/subscriber.go
@@ -272,20 +272,6 @@ func (p *API) GetSubscriberURLByResource(resource string) (urls []string) {
 	return urls
 }
 
-// GetClientIDByResource  get  subscriptionOne information
-func (p *API) GetClientIDByResource(resource string) (clientIDs []uuid.UUID) {
-	p.SubscriberStore.RLock()
-	defer p.SubscriberStore.RUnlock()
-	for _, subs := range p.SubscriberStore.Store {
-		for _, sub := range subs.SubStore.Store {
-			if strings.Contains(sub.GetResource(), resource) {
-				clientIDs = append(clientIDs, subs.ClientID)
-			}
-		}
-	}
-	return clientIDs
-}
-
 // GetClientIDBySubID ...
 func (p *API) GetClientIDBySubID(subID string) (clientIDs []uuid.UUID) {
 	p.SubscriberStore.RLock()
@@ -300,7 +286,7 @@ func (p *API) GetClientIDBySubID(subID string) (clientIDs []uuid.UUID) {
 	return clientIDs
 }
 
-// GetClientIDAddressByResource  get  subscriptionOne information
+// GetClientIDAddressByResource get subscriptionOne information
 func (p *API) GetClientIDAddressByResource(resource string) map[uuid.UUID]*types.URI {
 	clients := map[uuid.UUID]*types.URI{}
 	p.SubscriberStore.RLock()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -71,7 +71,7 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/redhat-cne/sdk-go v1.22.0
+# github.com/redhat-cne/sdk-go v1.22.2
 ## explicit; go 1.22
 github.com/redhat-cne/sdk-go/pkg/channel
 github.com/redhat-cne/sdk-go/pkg/common


### PR DESCRIPTION
Current code checking for existing subscription by resourceAddress only. This fix added checking for EndpointURI so that multiple clients (with different EndpointURIs) can create subscriptions for the same resourceAddress.