### PR TITLE
OCPBUGS-54543: Data race in Server.status access causes instability in cloud-event-proxy

### DIFF
--- a/v2/server_test.go
+++ b/v2/server_test.go
@@ -46,20 +46,22 @@ import (
 var (
 	server *restapi.Server
 
-	eventOutCh      chan *channel.DataChan
-	closeCh         chan struct{}
-	wg              sync.WaitGroup
-	port            = 8990
-	apHost          = "localhost"
-	apPath          = "/api/ocloudNotifications/v2/"
-	resource        = "/east-edge-10/Node3/sync/sync-status/sync-state"
-	resourceInvalid = "/east-edge-10/Node3/invalid"
-	storePath       = "."
-	ObjSub          pubsub.PubSub
-	ObjPub          pubsub.PubSub
-	testSource      = "/sync/sync-status/sync-state"
-	testType        = "event.synchronization-state-change"
-	endpoint        = "http://localhost:8990//api/ocloudNotifications/v2/dummy"
+	eventOutCh       chan *channel.DataChan
+	closeCh          chan struct{}
+	wg               sync.WaitGroup
+	port             = 8990
+	apHost           = "localhost"
+	apPath           = "/api/ocloudNotifications/v2/"
+	resource         = "/east-edge-10/Node3/sync/sync-status/sync-state"
+	resourceInvalid  = "/east-edge-10/Node3/invalid"
+	storePath        = "."
+	ObjSub           pubsub.PubSub
+	ObjPub           pubsub.PubSub
+	testSource       = "/sync/sync-status/sync-state"
+	testType         = "event.synchronization-state-change"
+	endpoint         = "http://localhost:8990//api/ocloudNotifications/v2/dummy"
+	onceCloseEvent   sync.Once
+	onceCloseCloseCh sync.Once
 )
 
 func onReceiveOverrideFn(e cloudevents.Event, d *channel.DataChan) error {
@@ -772,8 +774,15 @@ func TestServer_End(*testing.T) {
 	}
 	os.Remove("pub.json")
 	os.Remove("sub.json")
-	close(eventOutCh)
-	close(closeCh)
+	// hanlding go test -race ./...
+	// by closing channel only once
+	onceCloseEvent.Do(func() {
+		close(eventOutCh)
+	})
+
+	onceCloseCloseCh.Do(func() {
+		close(closeCh)
+	})
 }
 
 // Rest client to make http request
@@ -828,4 +837,36 @@ func (r *Rest) PostEvent(url *types.URI, e event.Event) error {
 		return fmt.Errorf("post returned status %d", status)
 	}
 	return nil
+}
+
+func TestServerStatusConcurrency(*testing.T) {
+	s := &restapi.Server{} // Adjust import as needed if your package name differs
+	statuses := []restapi.ServerStatus{
+		0,
+		1,
+		2,
+		3,
+	}
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Writer goroutine: updates status multiple times
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			s.SetStatus(statuses[i%len(statuses)])
+			time.Sleep(1 * time.Millisecond)
+		}
+	}()
+
+	// Reader goroutine: reads Ready() status
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			_ = s.Ready()
+			time.Sleep(1 * time.Millisecond)
+		}
+	}()
+
+	wg.Wait()
 }


### PR DESCRIPTION
This PR fixes a data race condition reported by the Go race detector during concurrent access to the Server.status field.
Issue:
    The status field in Server was being written from a goroutine inside wait.Until() and read from the Ready() method.
    This led to unsynchronized access across goroutines, resulting in a race condition.
Fix:
    Introduced a sync.RWMutex (statusLock) to guard reads and writes to the status field.
    Writes (e.g., in Start) now use statusLock.Lock().
    Reads (e.g., in Ready()) now use statusLock.RLock().