### PR TITLE
Return 404 from getCurrentState for unavailable event data

### DIFF
--- a/v2/routes.go
+++ b/v2/routes.go
@@ -40,6 +40,13 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	// EVENT_NOT_FOUND is a special resource address set when event data is not found.
+	// It is used in POST /subscriptions to test EndpointURI in order to successfully
+	// create a subscription when event data is not available.
+	EVENT_NOT_FOUND = "event-not-found"
+)
+
 // createSubscription create subscription and send it to a channel that is shared by middleware to process
 // Creates a new subscription .
 // If subscription exists with same resource then existing subscription is returned .
@@ -485,10 +492,22 @@ func (s *Server) getCurrentState(w http.ResponseWriter, r *http.Request) {
 	if s.statusReceiveOverrideFn != nil {
 		if statusErr := s.statusReceiveOverrideFn(*e, &out); statusErr != nil {
 			respondWithStatusCode(w, http.StatusNotFound, statusErr.Error())
-		} else if out.Data != nil {
-			respondWithJSON(w, http.StatusOK, *out.Data)
-		} else {
+		} else if out.Data == nil {
 			respondWithStatusCode(w, http.StatusNotFound, fmt.Sprintf("event not found for %s", resourceAddress))
+		} else {
+			// Unmarshal the cloud event data to check for resource data
+			var eventData cne.Data
+			if out.Data.Data() == nil {
+				respondWithStatusCode(w, http.StatusNotFound, fmt.Sprintf("event data is empty for %s", resourceAddress))
+			} else if err := json.Unmarshal(out.Data.Data(), &eventData); err != nil {
+				respondWithStatusCode(w, http.StatusNotFound, fmt.Sprintf("failed to unmarshal event data for %s: %v", resourceAddress, err))
+			} else if len(eventData.Values) == 0 || eventData.Values[0].Resource == "" {
+				respondWithStatusCode(w, http.StatusNotFound, fmt.Sprintf("event data invalid for %s", resourceAddress))
+			} else if eventData.Values[0].Resource == EVENT_NOT_FOUND {
+				respondWithStatusCode(w, http.StatusNotFound, fmt.Sprintf("event resource not found for %s", resourceAddress))
+			} else {
+				respondWithJSON(w, http.StatusOK, *out.Data)
+			}
 		}
 	} else {
 		respondWithStatusCode(w, http.StatusNotFound, "onReceive function not defined")


### PR DESCRIPTION
When event data is not available (e.g., event socket not ready), the `getCurrentState` function returned a FREERUN state with a ResourceAddress of "event-not-found". This incorrect state could cause a cell site outage.

This change modifies the function to return a 404 Not Found status in this scenario, preventing the potential outage.
