### PR TITLE
correct detection of event-not-found and ptp-not-set

### DIFF
--- a/v2/routes.go
+++ b/v2/routes.go
@@ -41,10 +41,14 @@ import (
 )
 
 const (
-	// EVENT_NOT_FOUND is a special resource address set when event data is not found.
-	// It is used in POST /subscriptions to test EndpointURI in order to successfully
+	// the following special resource addresses are used in POST /subscriptions to
+	// send initial notification to test EndpointURI in order to successfully
 	// create a subscription when event data is not available.
-	EVENT_NOT_FOUND = "event-not-found"
+
+	// EventNotFound is a special resource address set when event data is not found.
+	EventNotFound = "event-not-found"
+	// PTPNotSet is a special resource address set when PTP stats is not yet populated.
+	PTPNotSet = "ptp-not-set"
 )
 
 // createSubscription create subscription and send it to a channel that is shared by middleware to process
@@ -503,8 +507,8 @@ func (s *Server) getCurrentState(w http.ResponseWriter, r *http.Request) {
 				respondWithStatusCode(w, http.StatusNotFound, fmt.Sprintf("failed to unmarshal event data for %s: %v", resourceAddress, err))
 			} else if len(eventData.Values) == 0 || eventData.Values[0].Resource == "" {
 				respondWithStatusCode(w, http.StatusNotFound, fmt.Sprintf("event data invalid for %s", resourceAddress))
-			} else if eventData.Values[0].Resource == EVENT_NOT_FOUND {
-				respondWithStatusCode(w, http.StatusNotFound, fmt.Sprintf("event resource not found for %s", resourceAddress))
+			} else if strings.HasSuffix(eventData.Values[0].Resource, EventNotFound) || strings.HasSuffix(eventData.Values[0].Resource, PTPNotSet) {
+				respondWithStatusCode(w, http.StatusNotFound, fmt.Sprintf("event data not found for %s", resourceAddress))
 			} else {
 				respondWithJSON(w, http.StatusOK, *out.Data)
 			}

--- a/v2/server_test.go
+++ b/v2/server_test.go
@@ -598,7 +598,7 @@ func onReceiveOverrideFnEventNotFound(e cloudevents.Event, d *channel.DataChan) 
 
 	data := &event.Data{
 		Version: event.APISchemaVersion,
-		Values:  []event.DataValue{{Resource: "event-not-found", DataType: event.NOTIFICATION, ValueType: event.ENUMERATION, Value: ptp.FREERUN}},
+		Values:  []event.DataValue{{Resource: "/east-edge-10/Node3/event-not-found", DataType: event.NOTIFICATION, ValueType: event.ENUMERATION, Value: ptp.FREERUN}},
 	}
 	ce := cloudevents.NewEvent(cloudevents.VersionV1)
 	ce.SetTime(types.Timestamp{Time: time.Now().UTC()}.Time)
@@ -611,8 +611,44 @@ func onReceiveOverrideFnEventNotFound(e cloudevents.Event, d *channel.DataChan) 
 
 	return nil
 }
-func TestServer_GetCurrentState_KO_event_not_found(t *testing.T) {
+func TestServer_GetCurrentState_KO_EventNotFound(t *testing.T) {
 	server.SetOnStatusReceiveOverrideFn(onReceiveOverrideFnEventNotFound)
+	ctx := context.Background()
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("http://localhost:%d%s%s/%s", port, apPath, ObjSub.Resource, "CurrentState"), nil)
+	assert.Nil(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := server.HTTPClient.Do(req)
+	assert.Nil(t, err)
+	defer resp.Body.Close()
+	s, err2 := io.ReadAll(resp.Body)
+	assert.Nil(t, err2)
+	log.Infof("tedt %s ", string(s))
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func onReceiveOverrideFnPTPNotSet(e cloudevents.Event, d *channel.DataChan) error {
+	if e.Source() != resource {
+		return fmt.Errorf("could not find any events for requested resource type %s", e.Source())
+	}
+
+	data := &event.Data{
+		Version: event.APISchemaVersion,
+		Values:  []event.DataValue{{Resource: "/east-edge-10/Node3/ptp-not-set", DataType: event.NOTIFICATION, ValueType: event.ENUMERATION, Value: ptp.FREERUN}},
+	}
+	ce := cloudevents.NewEvent(cloudevents.VersionV1)
+	ce.SetTime(types.Timestamp{Time: time.Now().UTC()}.Time)
+	ce.SetType(testType)
+	ce.SetSource(testSource)
+	ce.SetSpecVersion(cloudevents.VersionV1)
+	ce.SetID(uuid.New().String())
+	ce.SetData("", *data) //nolint:errcheck
+	d.Data = &ce
+
+	return nil
+}
+
+func TestServer_GetCurrentState_KO_PTPNotSet(t *testing.T) {
+	server.SetOnStatusReceiveOverrideFn(onReceiveOverrideFnPTPNotSet)
 	ctx := context.Background()
 	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("http://localhost:%d%s%s/%s", port, apPath, ObjSub.Resource, "CurrentState"), nil)
 	assert.Nil(t, err)


### PR DESCRIPTION
The previous fix did not correctly detect when an event was not found. This commit fixes the logic to ensure that "event-not-found" is properly detected when it is part of full address with node info.

Also added similar detection and handling for "ptp-not-set".