### PR TITLE
v2: Return 404 from getCurrentState for unavailable event data (#103)

### DIFF
--- a/v2/routes.go
+++ b/v2/routes.go
@@ -40,6 +40,17 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	// the following special resource addresses are used in POST /subscriptions to
+	// send initial notification to test EndpointURI in order to successfully
+	// create a subscription when event data is not available.
+
+	// EventNotFound is a special resource address set when event data is not found.
+	EventNotFound = "event-not-found"
+	// PTPNotSet is a special resource address set when PTP stats is not yet populated.
+	PTPNotSet = "ptp-not-set"
+)
+
 // createSubscription create subscription and send it to a channel that is shared by middleware to process
 // Creates a new subscription .
 // If subscription exists with same resource then existing subscription is returned .
@@ -487,10 +498,22 @@ func (s *Server) getCurrentState(w http.ResponseWriter, r *http.Request) {
 	if s.statusReceiveOverrideFn != nil {
 		if statusErr := s.statusReceiveOverrideFn(*e, &out); statusErr != nil {
 			respondWithStatusCode(w, http.StatusNotFound, statusErr.Error())
-		} else if out.Data != nil {
-			respondWithJSON(w, http.StatusOK, *out.Data)
-		} else {
+		} else if out.Data == nil {
 			respondWithStatusCode(w, http.StatusNotFound, fmt.Sprintf("event not found for %s", resourceAddress))
+		} else {
+			// Unmarshal the cloud event data to check for resource data
+			var eventData cne.Data
+			if out.Data.Data() == nil {
+				respondWithStatusCode(w, http.StatusNotFound, fmt.Sprintf("event data is empty for %s", resourceAddress))
+			} else if err := json.Unmarshal(out.Data.Data(), &eventData); err != nil {
+				respondWithStatusCode(w, http.StatusNotFound, fmt.Sprintf("failed to unmarshal event data for %s: %v", resourceAddress, err))
+			} else if len(eventData.Values) == 0 || eventData.Values[0].Resource == "" {
+				respondWithStatusCode(w, http.StatusNotFound, fmt.Sprintf("event data invalid for %s", resourceAddress))
+			} else if strings.HasSuffix(eventData.Values[0].Resource, EventNotFound) || strings.HasSuffix(eventData.Values[0].Resource, PTPNotSet) {
+				respondWithStatusCode(w, http.StatusNotFound, fmt.Sprintf("event data not found for %s", resourceAddress))
+			} else {
+				respondWithJSON(w, http.StatusOK, *out.Data)
+			}
 		}
 	} else {
 		respondWithStatusCode(w, http.StatusNotFound, "onReceive function not defined")

--- a/v2/server_test.go
+++ b/v2/server_test.go
@@ -71,7 +71,7 @@ func onReceiveOverrideFn(e cloudevents.Event, d *channel.DataChan) error {
 
 	data := &event.Data{
 		Version: event.APISchemaVersion,
-		Values:  []event.DataValue{},
+		Values:  []event.DataValue{{Resource: resource, DataType: event.NOTIFICATION, ValueType: event.ENUMERATION, Value: ptp.FREERUN}},
 	}
 	ce := cloudevents.NewEvent(cloudevents.VersionV1)
 	ce.SetTime(types.Timestamp{Time: time.Now().UTC()}.Time)
@@ -512,6 +512,145 @@ func TestServer_GetCurrentState_KO_ResourceInvalid(t *testing.T) {
 	// try getting event
 	time.Sleep(2 * time.Second)
 	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("http://localhost:%d%s%s/%s", port, apPath, resourceInvalid, "CurrentState"), nil)
+	assert.Nil(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := server.HTTPClient.Do(req)
+	assert.Nil(t, err)
+	defer resp.Body.Close()
+	s, err2 := io.ReadAll(resp.Body)
+	assert.Nil(t, err2)
+	log.Infof("tedt %s ", string(s))
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func onReceiveOverrideFnEmptyEventData(e cloudevents.Event, d *channel.DataChan) error {
+	if e.Source() != resource {
+		return fmt.Errorf("could not find any events for requested resource type %s", e.Source())
+	}
+
+	ce := cloudevents.NewEvent(cloudevents.VersionV1)
+	ce.SetTime(types.Timestamp{Time: time.Now().UTC()}.Time)
+	ce.SetType(testType)
+	ce.SetSource(testSource)
+	ce.SetSpecVersion(cloudevents.VersionV1)
+	ce.SetID(uuid.New().String())
+	ce.SetData("", nil) //nolint:errcheck
+	d.Data = &ce
+
+	return nil
+}
+
+func TestServer_GetCurrentState_KO_EmptyEventData(t *testing.T) {
+	server.SetOnStatusReceiveOverrideFn(onReceiveOverrideFnEmptyEventData)
+	ctx := context.Background()
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("http://localhost:%d%s%s/%s", port, apPath, ObjSub.Resource, "CurrentState"), nil)
+	assert.Nil(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := server.HTTPClient.Do(req)
+	assert.Nil(t, err)
+	defer resp.Body.Close()
+	s, err2 := io.ReadAll(resp.Body)
+	assert.Nil(t, err2)
+	log.Infof("tedt %s ", string(s))
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func onReceiveOverrideFnInvalidEventData(e cloudevents.Event, d *channel.DataChan) error {
+	if e.Source() != resource {
+		return fmt.Errorf("could not find any events for requested resource type %s", e.Source())
+	}
+
+	data := &event.Data{
+		Version: event.APISchemaVersion,
+		Values:  []event.DataValue{},
+	}
+	ce := cloudevents.NewEvent(cloudevents.VersionV1)
+	ce.SetTime(types.Timestamp{Time: time.Now().UTC()}.Time)
+	ce.SetType(testType)
+	ce.SetSource(testSource)
+	ce.SetSpecVersion(cloudevents.VersionV1)
+	ce.SetID(uuid.New().String())
+	ce.SetData("", *data) //nolint:errcheck
+	d.Data = &ce
+
+	return nil
+}
+
+func TestServer_GetCurrentState_KO_InvalidEventData(t *testing.T) {
+	server.SetOnStatusReceiveOverrideFn(onReceiveOverrideFnInvalidEventData)
+	ctx := context.Background()
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("http://localhost:%d%s%s/%s", port, apPath, ObjSub.Resource, "CurrentState"), nil)
+	assert.Nil(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := server.HTTPClient.Do(req)
+	assert.Nil(t, err)
+	defer resp.Body.Close()
+	s, err2 := io.ReadAll(resp.Body)
+	assert.Nil(t, err2)
+	log.Infof("tedt %s ", string(s))
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func onReceiveOverrideFnEventNotFound(e cloudevents.Event, d *channel.DataChan) error {
+	if e.Source() != resource {
+		return fmt.Errorf("could not find any events for requested resource type %s", e.Source())
+	}
+
+	data := &event.Data{
+		Version: event.APISchemaVersion,
+		Values:  []event.DataValue{{Resource: "/east-edge-10/Node3/event-not-found", DataType: event.NOTIFICATION, ValueType: event.ENUMERATION, Value: ptp.FREERUN}},
+	}
+	ce := cloudevents.NewEvent(cloudevents.VersionV1)
+	ce.SetTime(types.Timestamp{Time: time.Now().UTC()}.Time)
+	ce.SetType(testType)
+	ce.SetSource(testSource)
+	ce.SetSpecVersion(cloudevents.VersionV1)
+	ce.SetID(uuid.New().String())
+	ce.SetData("", *data) //nolint:errcheck
+	d.Data = &ce
+
+	return nil
+}
+func TestServer_GetCurrentState_KO_EventNotFound(t *testing.T) {
+	server.SetOnStatusReceiveOverrideFn(onReceiveOverrideFnEventNotFound)
+	ctx := context.Background()
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("http://localhost:%d%s%s/%s", port, apPath, ObjSub.Resource, "CurrentState"), nil)
+	assert.Nil(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := server.HTTPClient.Do(req)
+	assert.Nil(t, err)
+	defer resp.Body.Close()
+	s, err2 := io.ReadAll(resp.Body)
+	assert.Nil(t, err2)
+	log.Infof("tedt %s ", string(s))
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func onReceiveOverrideFnPTPNotSet(e cloudevents.Event, d *channel.DataChan) error {
+	if e.Source() != resource {
+		return fmt.Errorf("could not find any events for requested resource type %s", e.Source())
+	}
+
+	data := &event.Data{
+		Version: event.APISchemaVersion,
+		Values:  []event.DataValue{{Resource: "/east-edge-10/Node3/ptp-not-set", DataType: event.NOTIFICATION, ValueType: event.ENUMERATION, Value: ptp.FREERUN}},
+	}
+	ce := cloudevents.NewEvent(cloudevents.VersionV1)
+	ce.SetTime(types.Timestamp{Time: time.Now().UTC()}.Time)
+	ce.SetType(testType)
+	ce.SetSource(testSource)
+	ce.SetSpecVersion(cloudevents.VersionV1)
+	ce.SetID(uuid.New().String())
+	ce.SetData("", *data) //nolint:errcheck
+	d.Data = &ce
+
+	return nil
+}
+
+func TestServer_GetCurrentState_KO_PTPNotSet(t *testing.T) {
+	server.SetOnStatusReceiveOverrideFn(onReceiveOverrideFnPTPNotSet)
+	ctx := context.Background()
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("http://localhost:%d%s%s/%s", port, apPath, ObjSub.Resource, "CurrentState"), nil)
 	assert.Nil(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := server.HTTPClient.Do(req)


### PR DESCRIPTION
* Return 404 from getCurrentState for unavailable event data (#100)

When event data is not available (e.g., event socket not ready), the `getCurrentState` function returned a FREERUN state with a ResourceAddress of "event-not-found". This incorrect state could cause a cell site outage.

This change modifies the function to return a 404 Not Found status in this scenario, preventing the potential outage.



* fix: correct detection of event-not-found and ptp-not-set (#102)

The previous fix did not correctly detect when an event was not found. This commit fixes the logic to ensure that "event-not-found" is properly detected when it is part of full address with node info.

Also added similar detection and handling for "ptp-not-set".



---------